### PR TITLE
Fixed data after pantherdb/pango#65

### DIFF
--- a/2025-01-27_2.0.3/full_go_annotated.json
+++ b/2025-01-27_2.0.3/full_go_annotated.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24306bfdb6702c33d7c9a4b5b1a3657342280491a059a6d2841b78c76ce832ba
+size 6300553

--- a/2025-01-27_2.0.3/human_iba_annotations.json
+++ b/2025-01-27_2.0.3/human_iba_annotations.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0a249b05537ee5eccdbc473758bb2c8263e0b3f51371509359c0f51762418f8
+size 49556553

--- a/2025-01-27_2.0.3/human_iba_gene_info.json
+++ b/2025-01-27_2.0.3/human_iba_gene_info.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae655314fbff8517c09452aeaecb59640229a7c24d2286a146d9358dc8ba83c3
+size 11625444

--- a/2025-01-27_2.0.3/taxon_lkp.json
+++ b/2025-01-27_2.0.3/taxon_lkp.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06d900551227c041c391f4418b433ffbdcaaa5b4cbf4ef382144a2854fcdd670
+size 6206


### PR DESCRIPTION
Data generated after applying fix for pantherdb/pango#65.
Source IBA GAF used is [paint_goa_human.gaf](https://release.geneontology.org/2024-11-03/products/upstream_and_raw_data/paint_goa_human.gaf.gz) from 2024-11-03 GO release.

@tmushayahama When you have a chance, could you load these files into a PAN-GO test instance?