### PR TITLE
Updated release based on GO release 2025-03-16

### DIFF
--- a/2025-08-18_2.0.4/full_go_annotated.json
+++ b/2025-08-18_2.0.4/full_go_annotated.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c454001f3453534599c903637ea71f4e7dafd76036baec4ee89f7e9a35d84b3e
+size 6318110

--- a/2025-08-18_2.0.4/human_iba_annotations.json
+++ b/2025-08-18_2.0.4/human_iba_annotations.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:145035f2c1bf8f6c1441b398ca4f44302a4f9fd9dc36135a033a57a3143d97bb
+size 48015616

--- a/2025-08-18_2.0.4/human_iba_gene_info.json
+++ b/2025-08-18_2.0.4/human_iba_gene_info.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4c6acebfd5766193657b445217dacd2dbe675663d0e4810d0455d807dfc454e
+size 11657048

--- a/2025-08-18_2.0.4/taxon_lkp.json
+++ b/2025-08-18_2.0.4/taxon_lkp.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1e1ac43f28622414e125aa9868817a53d389b69049c57ca94882741d086becc
+size 6358


### PR DESCRIPTION
Pan-GO annotation and ontology data parsed from [2025-03-16](https://release.geneontology.org/2025-03-16/index.html) GO release.