### PR TITLE
Updated files based on 2025-09-09 IBA release

### DIFF
--- a/2025-10-12_2.0.5/full_go_annotated.json
+++ b/2025-10-12_2.0.5/full_go_annotated.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bba7c40951fb5c4f5085286114ef9495a4be3c2ab0319d949c7a262695004dc
+size 6349614

--- a/2025-10-12_2.0.5/human_iba_annotations.json
+++ b/2025-10-12_2.0.5/human_iba_annotations.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50b5f42dc3d465aebb425960d53123573e28b2ef10e0e59361409f86b001560c
+size 55028315

--- a/2025-10-12_2.0.5/human_iba_gene_info.json
+++ b/2025-10-12_2.0.5/human_iba_gene_info.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:284fbd35e11009781d8fa151b597925d6cf001a5dcdd6cf3c1cccff5095d88e8
+size 11935407

--- a/2025-10-12_2.0.5/taxon_lkp.json
+++ b/2025-10-12_2.0.5/taxon_lkp.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1e1ac43f28622414e125aa9868817a53d389b69049c57ca94882741d086becc
+size 6358


### PR DESCRIPTION
Updated files Pan-GO for 2.0 release.

The 2025-09-09 IBA human GAF data validated against Alex's UniProt-centric GOEx human GAF: `HUMAN_9606_UP000005640.gaf`. Then converted into JSON.