### PR TITLE
Update data after has_gene_symbol field added

### DIFF
--- a/2026-01-05_2.0.7/full_go_annotated.json
+++ b/2026-01-05_2.0.7/full_go_annotated.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bba7c40951fb5c4f5085286114ef9495a4be3c2ab0319d949c7a262695004dc
+size 6349614

--- a/2026-01-05_2.0.7/human_iba_annotations.json
+++ b/2026-01-05_2.0.7/human_iba_annotations.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2568077f57974bc3be9da3d13dd4ac00ba605c1c683c567cba1eaf1ad66e6dff
+size 52138337

--- a/2026-01-05_2.0.7/human_iba_gene_info.json
+++ b/2026-01-05_2.0.7/human_iba_gene_info.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56d425132f12d23c91a42b9e360d1c2581a6c8b08de93a4b1f218a7aef0c1757
+size 13228740

--- a/2026-01-05_2.0.7/taxon_lkp.json
+++ b/2026-01-05_2.0.7/taxon_lkp.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0faf51edbaefce6a53a123e8aff2713e0dfd236cc193bac610db9df250485c96
+size 6239


### PR DESCRIPTION
For pantherdb/pango#89.

Noting this should be the same annotation data as in the previous release #4.