### PR TITLE
Add new GO hierarchy file

### DIFF
--- a/2026-01-05_2.0.7/go_hierarchy.json
+++ b/2026-01-05_2.0.7/go_hierarchy.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f5f01eecf7d4a67baceeccc7db6e1b3c47072f9bf510d891255d93ef7b20dde
+size 250247


### PR DESCRIPTION
For pantherdb/pango#94. Just adding a new file to `2.0.7`.