### PR TITLE
Add go_hierarchy.json for v1.0 data

### DIFF
--- a/2023-08-11_1.0/go_hierarchy.json
+++ b/2023-08-11_1.0/go_hierarchy.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bab882bf0c65036a1555a4f59b3330c9341c96f79e5df0709170919d6fea5abf
+size 269417


### PR DESCRIPTION
For pantherdb/pango#94. Adding this to older v1.0 data folder for compatibility with new UI code. Generated from [2022-03-22 go.obo](https://release.geneontology.org/2022-03-22/ontology/go.obo).