### PR TITLE
Regen gene_info.json w/ has_gene_symbol for pantherdb/pango#89

### DIFF
--- a/2023-08-11_1.0/human_iba_gene_info.json
+++ b/2023-08-11_1.0/human_iba_gene_info.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:49b5981acf721b0cfb643c69b52b046f5664159e1d91b83b890182c6b6112862
-size 11380779
+oid sha256:0a2df29d146fbba07cc170fb6e87c0387119c8dbc1a9e31856360febbe40d6ca
+size 12512793


### PR DESCRIPTION
For pantherdb/pango#89. Gene info data structure now requires `has_gene_symbol` by the Pan-GO UI.

Tagging @tmushayahama that this is now updated.